### PR TITLE
fix(ci): use GoReleaser v2 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The release workflow was failing because `.goreleaser.yml` specifies `version: 2`, but the workflow was using `version: latest` which installed GoReleaser v1.26.2 (only supports version 1 configs).

Error:

```
⨯ release failed after 0s error=only configurations files on version: 1 are supported, yours is version: 2, please update your configuration
```

## Solution

Updated the workflow to use `version: "~> v2"` to ensure GoReleaser v2.x is installed, which supports the version 2 configuration format.

## Changes

- Updated `.github/workflows/release.yml` to use `version: "~> v2"` instead of `version: latest`

Fixes #9