### PR TITLE
feat(ci): add dry-run mode to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,22 @@ name: Release
 on:
   release:
     types: [published]
-
-permissions:
-  contents: write
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no releases or commits)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Permissions set to write for normal releases. In dry-run mode, conditional steps
+    # prevent any commits or releases, so no writes occur despite write permissions.
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,6 +31,15 @@ jobs:
         with:
           go-version: '1.21'
 
+      - name: Check dry-run mode
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" == "true" ]; then
+            echo "🚀 DRY-RUN MODE: No releases or commits will be created"
+            echo "This run will validate the release process without making any changes to the repository."
+          else
+            echo "📦 NORMAL MODE: This run will create releases and commit changes."
+          fi
+
       - name: Install git-chglog
         run: go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest
 
@@ -31,7 +48,22 @@ jobs:
           export PATH="$PATH:$(go env GOPATH)/bin"
           git-chglog --output CHANGELOG.md
 
+      - name: Display Changelog (dry-run only)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+        run: |
+          echo "=== Generated Changelog ==="
+          cat CHANGELOG.md
+          echo "=== End of Changelog ==="
+
+      - name: Upload Changelog Artifact (dry-run only)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-dry-run
+          path: CHANGELOG.md
+
       - name: Commit Changelog
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -43,7 +75,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '--snapshot --clean' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,50 @@ git-chglog --output CHANGELOG.md
    - Commit the updated changelog to the repository
    - Use GoReleaser to create the GitHub release with changelog entries
 
+**Testing Release Process (Dry-Run Mode)**:
+
+The release workflow supports a dry-run mode that allows you to test the entire release process without creating actual releases, committing changes, or publishing artifacts. This is useful for:
+
+- Validating GoReleaser configuration changes before merging PRs
+- Testing changelog generation with new commits without creating releases
+- Verifying release workflow changes in pull requests
+- Debugging release issues without creating test releases
+- Validating artifact builds across all target platforms (linux/darwin, amd64/arm64)
+
+**How to use dry-run mode**:
+
+1. Navigate to the [Actions](https://github.com/sv4u/touchlog/actions) tab in GitHub
+2. Select the "Release" workflow from the left sidebar
+3. Click "Run workflow" button (top right)
+4. Check the "Run in dry-run mode (no releases or commits)" checkbox
+5. Click "Run workflow" to start the dry-run
+
+**What dry-run mode does**:
+
+- ✅ Generates the changelog from commits since the last release
+- ✅ Validates GoReleaser configuration
+- ✅ Builds artifacts for all target platforms (linux/darwin, amd64/arm64)
+- ✅ Displays the generated changelog in workflow logs
+- ✅ Uploads the changelog as a downloadable artifact
+- ✅ Uses GoReleaser's `--snapshot` mode (skips publishing and validations)
+
+**What dry-run mode does NOT do**:
+
+- ❌ Create GitHub releases
+- ❌ Commit changes to the repository
+- ❌ Publish artifacts
+- ❌ Consume GitHub API rate limits for releases
+
+**Accessing the changelog artifact**:
+
+After the dry-run workflow completes:
+
+1. Go to the workflow run page
+2. Scroll down to the "Artifacts" section
+3. Download the `changelog-dry-run` artifact to view the generated changelog
+
+**Note**: The dry-run mode uses GoReleaser's `--snapshot` flag, which generates unversioned snapshot releases without publishing. This allows you to validate the build process and configuration without affecting the repository.
+
 ## License
 
 See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Adds a dry-run mode to the release workflow that enables safe testing of the entire release process without creating actual GitHub releases, committing changes, or publishing artifacts.

## Changes

- Add `workflow_dispatch` trigger with optional `dry_run` boolean input
- Conditionally skip changelog commit when `dry_run=true`
- Use GoReleaser `--snapshot` flag in dry-run mode
- Upload changelog as artifact and display in logs for dry-run runs
- Add comprehensive documentation in README.md
- Guard all `inputs.dry_run` access with `github.event_name` checks to prevent errors when triggered by release events

## Testing

- [ ] Test dry-run mode via workflow_dispatch with `dry_run=true`
- [ ] Verify no commits are made when `dry_run=true`
- [ ] Verify no GitHub releases are created when `dry_run=true`
- [ ] Verify changelog is generated and available as artifact
- [ ] Test normal release flow via release event to ensure backward compatibility

## Related

Closes #10